### PR TITLE
Updated cli-go to 0.5.0-alpha-6

### DIFF
--- a/deploifai.json
+++ b/deploifai.json
@@ -1,0 +1,22 @@
+{
+    "version": "0.5.0-alpha-6",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-6/deploifai_Windows_i386.zip",
+            "bin": [
+                "deploifai.exe"
+            ],
+            "hash": "5d7c93aeb84c2896f66da3ac835fac8db9466f8197f1abb7d70c5553c2a4a257"
+        },
+        "64bit": {
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-6/deploifai_Windows_x86_64.zip",
+            "bin": [
+                "deploifai.exe"
+            ],
+            "hash": "d1243f11a58feb629e41fe83458250c751d61f6887bd436e0457b6e0fcef47c6"
+        }
+    },
+    "homepage": "https://deploif.ai",
+    "license": "MIT",
+    "description": "CLI tool for Deploifai"
+}


### PR DESCRIPTION
Automatically generated by [GoReleaser](https://goreleaser.com)