### PR TITLE
Updated cli-go to 0.5.0-alpha-7

### DIFF
--- a/deploifai.json
+++ b/deploifai.json
@@ -1,19 +1,19 @@
 {
-    "version": "0.5.0-alpha-6",
+    "version": "0.5.0-alpha-7",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-6/deploifai_Windows_i386.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-7/deploifai_Windows_i386.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "5d7c93aeb84c2896f66da3ac835fac8db9466f8197f1abb7d70c5553c2a4a257"
+            "hash": "cdb0f6c8c9d490784ad5b249d37a4a0c47c0f5d0a1580f64bb304fb78859b955"
         },
         "64bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-6/deploifai_Windows_x86_64.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-7/deploifai_Windows_x86_64.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "d1243f11a58feb629e41fe83458250c751d61f6887bd436e0457b6e0fcef47c6"
+            "hash": "4f10132d5e2017091fbb143317c198d66d3c34068822c544102ffb9dd77b8e12"
         }
     },
     "homepage": "https://deploif.ai",


### PR DESCRIPTION
Automatically generated by [GoReleaser](https://goreleaser.com)