### PR TITLE
Updated cli-go to 0.5.0-alpha-8

### DIFF
--- a/deploifai.json
+++ b/deploifai.json
@@ -1,19 +1,19 @@
 {
-    "version": "0.5.0-alpha-6",
+    "version": "0.5.0-alpha-8",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-6/deploifai_Windows_i386.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-8/deploifai_Windows_i386.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "5d7c93aeb84c2896f66da3ac835fac8db9466f8197f1abb7d70c5553c2a4a257"
+            "hash": "3e7bdb21d3be6ea0e986474815cde1e44c48d82b641e16c3d391f346615fe53b"
         },
         "64bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-6/deploifai_Windows_x86_64.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-8/deploifai_Windows_x86_64.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "d1243f11a58feb629e41fe83458250c751d61f6887bd436e0457b6e0fcef47c6"
+            "hash": "1a74ea6fd514df424c73cd685b7b4e718fbfc6aeb24c9a2546c19f8e67c1040b"
         }
     },
     "homepage": "https://deploif.ai",


### PR DESCRIPTION
Automatically generated by [GoReleaser](https://goreleaser.com)