### PR TITLE
Updated cli-go to 0.5.0-alpha-9

### DIFF
--- a/deploifai.json
+++ b/deploifai.json
@@ -1,19 +1,19 @@
 {
-    "version": "0.5.0-alpha-6",
+    "version": "0.5.0-alpha-9",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-6/deploifai_Windows_i386.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-9/deploifai_Windows_i386.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "5d7c93aeb84c2896f66da3ac835fac8db9466f8197f1abb7d70c5553c2a4a257"
+            "hash": "246813cfdd044b9637ffbadf015c011aaeb42efe9c102a384b37786e37a918b3"
         },
         "64bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-6/deploifai_Windows_x86_64.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-9/deploifai_Windows_x86_64.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "d1243f11a58feb629e41fe83458250c751d61f6887bd436e0457b6e0fcef47c6"
+            "hash": "a7e8d2801e083d2c2f7bb1419f0df0d9d1c9ac5918c00e4f7ec19bed0a0b6674"
         }
     },
     "homepage": "https://deploif.ai",


### PR DESCRIPTION
Automatically generated by [GoReleaser](https://goreleaser.com)