### PR TITLE
Updated cli-go to 0.5.0-alpha-10

### DIFF
--- a/deploifai.json
+++ b/deploifai.json
@@ -1,19 +1,19 @@
 {
-    "version": "0.5.0-alpha-9",
+    "version": "0.5.0-alpha-10",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-9/deploifai_Windows_i386.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-10/deploifai_Windows_i386.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "246813cfdd044b9637ffbadf015c011aaeb42efe9c102a384b37786e37a918b3"
+            "hash": "49512588633837ac0e2a51180994e0443709d7a025b2b0b02b4d1c519766e38a"
         },
         "64bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-9/deploifai_Windows_x86_64.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-10/deploifai_Windows_x86_64.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "a7e8d2801e083d2c2f7bb1419f0df0d9d1c9ac5918c00e4f7ec19bed0a0b6674"
+            "hash": "abf022711a9f64b5794e1b7b4553d176991b20a41684f50922557330b6a0d7f8"
         }
     },
     "homepage": "https://deploif.ai",


### PR DESCRIPTION
Automatically generated by [GoReleaser](https://goreleaser.com)