### PR TITLE
Updated cli-go to 0.5.1

### DIFF
--- a/deploifai.json
+++ b/deploifai.json
@@ -1,19 +1,19 @@
 {
-    "version": "0.5.0-alpha-10",
+    "version": "0.5.1",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-10/deploifai_Windows_i386.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.1/deploifai_Windows_i386.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "49512588633837ac0e2a51180994e0443709d7a025b2b0b02b4d1c519766e38a"
+            "hash": "d2737b5e1bfcc0bb0e2575540174105628a0b4a216217fe161259854bd24253c"
         },
         "64bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.0-alpha-10/deploifai_Windows_x86_64.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.1/deploifai_Windows_x86_64.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "abf022711a9f64b5794e1b7b4553d176991b20a41684f50922557330b6a0d7f8"
+            "hash": "c2ca9f8e77300c8869620b18c2d6e3f42b271d25efdc3e38e983a5e31a5f74a2"
         }
     },
     "homepage": "https://deploif.ai",


### PR DESCRIPTION
Automatically generated by [GoReleaser](https://goreleaser.com)