### PR TITLE
Updated cli-go to 0.5.2

### DIFF
--- a/deploifai.json
+++ b/deploifai.json
@@ -1,19 +1,19 @@
 {
-    "version": "0.5.1",
+    "version": "0.5.2",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.1/deploifai_Windows_i386.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.2/deploifai_Windows_i386.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "d2737b5e1bfcc0bb0e2575540174105628a0b4a216217fe161259854bd24253c"
+            "hash": "7b9808529feb0030b9097e86a967caccf573fe540d6bc4a35b102395f83107a0"
         },
         "64bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.1/deploifai_Windows_x86_64.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.2/deploifai_Windows_x86_64.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "c2ca9f8e77300c8869620b18c2d6e3f42b271d25efdc3e38e983a5e31a5f74a2"
+            "hash": "9ad8aa074096c3b773b01bf3e3c861d97ef1679a5f5b5a903d3ae4d941300577"
         }
     },
     "homepage": "https://deploif.ai",


### PR DESCRIPTION
Automatically generated by [GoReleaser](https://goreleaser.com)