### PR TITLE
Updated cli-go to 0.5.3

### DIFF
--- a/deploifai.json
+++ b/deploifai.json
@@ -1,19 +1,19 @@
 {
-    "version": "0.5.2",
+    "version": "0.5.3",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.2/deploifai_Windows_i386.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.3/deploifai_Windows_i386.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "7b9808529feb0030b9097e86a967caccf573fe540d6bc4a35b102395f83107a0"
+            "hash": "453ad92a6be14b197ab0e323ffbeef0cdaf7af7003c8dc898e2cfe8afa0a926d"
         },
         "64bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.2/deploifai_Windows_x86_64.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.3/deploifai_Windows_x86_64.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "9ad8aa074096c3b773b01bf3e3c861d97ef1679a5f5b5a903d3ae4d941300577"
+            "hash": "5b3876a04ac9da031a84c2ad5fb79e57a3a0033076435a5fbb228ec23eef5c63"
         }
     },
     "homepage": "https://deploif.ai",


### PR DESCRIPTION
Automatically generated by [GoReleaser](https://goreleaser.com)