### PR TITLE
Updated cli-go to 0.5.4

### DIFF
--- a/deploifai.json
+++ b/deploifai.json
@@ -1,19 +1,19 @@
 {
-    "version": "0.5.3",
+    "version": "0.5.4",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.3/deploifai_Windows_i386.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.4/deploifai_Windows_i386.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "453ad92a6be14b197ab0e323ffbeef0cdaf7af7003c8dc898e2cfe8afa0a926d"
+            "hash": "177267e4b15435cc962c036acd2217c0e73d4cfab5873337267d61b262ae4975"
         },
         "64bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.3/deploifai_Windows_x86_64.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.4/deploifai_Windows_x86_64.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "5b3876a04ac9da031a84c2ad5fb79e57a3a0033076435a5fbb228ec23eef5c63"
+            "hash": "142fc7ce14c5e8e41185da43236e1f3ad92a6c39075adece1229124b79f00dc9"
         }
     },
     "homepage": "https://deploif.ai",


### PR DESCRIPTION
Automatically generated by [GoReleaser](https://goreleaser.com)