### PR TITLE
Updated cli-go to 0.5.5

### DIFF
--- a/deploifai.json
+++ b/deploifai.json
@@ -1,19 +1,19 @@
 {
-    "version": "0.5.4",
+    "version": "0.5.5",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.4/deploifai_Windows_i386.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.5/deploifai_Windows_i386.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "177267e4b15435cc962c036acd2217c0e73d4cfab5873337267d61b262ae4975"
+            "hash": "da02766246e30d7f7500dcd8cac4668b5620e21ecf4ecb1e15c72319193ce0a1"
         },
         "64bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.4/deploifai_Windows_x86_64.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.5/deploifai_Windows_x86_64.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "142fc7ce14c5e8e41185da43236e1f3ad92a6c39075adece1229124b79f00dc9"
+            "hash": "d32d99f53e77e34a6c06aec08a204c9e5c19b1b213a783ad6a546377f4ef212a"
         }
     },
     "homepage": "https://deploif.ai",


### PR DESCRIPTION
Automatically generated by [GoReleaser](https://goreleaser.com)