### PR TITLE
Updated cli-go to 0.5.6

### DIFF
--- a/deploifai.json
+++ b/deploifai.json
@@ -1,19 +1,19 @@
 {
-    "version": "0.5.5",
+    "version": "0.5.6",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.5/deploifai_Windows_i386.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.6/deploifai_Windows_i386.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "da02766246e30d7f7500dcd8cac4668b5620e21ecf4ecb1e15c72319193ce0a1"
+            "hash": "4d05c27c1656934e998469acb39b2b3f6eaaafe0c99a113d3cb4d8046d83deda"
         },
         "64bit": {
-            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.5/deploifai_Windows_x86_64.zip",
+            "url": "https://github.com/deploifai/cli-go/releases/download/v0.5.6/deploifai_Windows_x86_64.zip",
             "bin": [
                 "deploifai.exe"
             ],
-            "hash": "d32d99f53e77e34a6c06aec08a204c9e5c19b1b213a783ad6a546377f4ef212a"
+            "hash": "67a1ec2d4954891b0c6de19b83bf52ea8fe181b25e9af5d61c76eeeb13880d4e"
         }
     },
     "homepage": "https://deploif.ai",


### PR DESCRIPTION
Automatically generated by [GoReleaser](https://goreleaser.com)